### PR TITLE
[4pt] Details Page, [5pt] Main Page Cars list

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
     rescue ActiveRecord::RecordNotFound => e
       render json: { errors: e.message }, status: :unauthorized
     rescue JWT::DecodeError => e
-      render json: { errors: e.message }, status: :unauthorized
+      render json: { errors: "Invalid token" }, status: :unauthorized
     end
   end
 end

--- a/app/javascript/Router.js
+++ b/app/javascript/Router.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Route, Routes } from 'react-router';
-import Login from './components/Auth/Login';
-import Register from './components/Auth/Register';
-import Layout from './components/Layout';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import ToastContainer from './components/shared/ToastContainer';
+import Layout from './components/Layout';
+import { Login, Register } from './components/Auth';
+import Home from './components/cars/Home';
+import { Details } from './components/cars';
 
-function Router(props) {
+function Router() {
   const { user } = useSelector((state) => state.user);
 
   return (
@@ -14,10 +14,8 @@ function Router(props) {
       <Route path="" element={<Layout />}>
         {user ? (
           <>
-            <Route
-              path=""
-              element={<h1 className="bg-blue-400">Hello Home</h1>}
-            />
+            <Route path="cars" element={<Home />} />
+            <Route path="cars/:car_id" element={<Details />} />
             <Route
               path="reserve"
               element={<h1 className="bg-blue-400">Reserve a car</h1>}
@@ -34,6 +32,7 @@ function Router(props) {
               path="delete-car"
               element={<h1 className="bg-blue-400">Delete Cars</h1>}
             />
+            <Route path="/" element={<Navigate to={'cars'} />} />
           </>
         ) : (
           <>

--- a/app/javascript/components/Auth/AuthNavbar.jsx
+++ b/app/javascript/components/Auth/AuthNavbar.jsx
@@ -19,7 +19,7 @@ function AuthNavbar() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const links = [
-    { to: '', label: 'Cars' },
+    { to: 'cars', label: 'Cars' },
     { to: 'reserve', label: 'Reserve' },
     { to: 'reservations', label: 'My Reservations' },
     { to: 'add-car', label: 'Add Car' },
@@ -33,7 +33,7 @@ function AuthNavbar() {
   };
   return (
     <div className="flex flex-col justify-start items-start pl-4 border-r h-screen">
-      <Link to="/">
+      <Link to="/cars">
         <img src={Logo} alt="Logo" width="150px" height="150px" />
       </Link>
       <div className="text-sky-600 px-3 py-2 flex justify-between items-center text-xl w-full font-semibold">

--- a/app/javascript/components/Auth/index.js
+++ b/app/javascript/components/Auth/index.js
@@ -1,0 +1,3 @@
+export { default as AuthNavbar } from './AuthNavbar';
+export { default as Login } from './Login';
+export { default as Register } from './Register';

--- a/app/javascript/components/Layout.jsx
+++ b/app/javascript/components/Layout.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import Navbar from './Navbar';
-import AuthNavbar from './Auth/AuthNavbar';
 import { useSelector } from 'react-redux';
-import ToastContainer from './shared/ToastContainer';
+import Navbar from './Navbar';
+import { AuthNavbar } from './Auth';
+import { ToastContainer } from './shared';
 
 function Layout() {
   const { user } = useSelector((state) => state.user);

--- a/app/javascript/components/cars/Details.jsx
+++ b/app/javascript/components/cars/Details.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { BiLeftArrow } from 'react-icons/bi';
+import { FaCheck, FaCheckCircle } from 'react-icons/fa';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+
+function Details(props) {
+  const { car_id } = useParams();
+  const { cars } = useSelector((state) => state.car);
+  const car = cars.filter((car) => car.id === parseInt(car_id))[0];
+
+  return (
+    <div className="relative w-full h-screen flex flex-col justify-start items-center overflow-auto max-h-screen max-w-full">
+      <Link
+        to="/cars"
+        className="absolute left-0 bottom-8 bg-lime-500 text-white pl-8 py-4 pr-4 rounded-r-full"
+      >
+        <BiLeftArrow />
+      </Link>
+
+      <div className="flex justify-center items-center gap-x-4">
+        <div
+          className={`flex md:w-3/4 w-1/2 justify-center items-center h-screen overflow-visible rounded-full max-w-fit`}
+        >
+          <img
+            src={car.image_url}
+            className="max-w-full"
+            alt={`${car.model}-image`}
+          />
+        </div>
+        <div className="md:w-1/4 w-1/2 px-4">
+          <h1 className="text-3xl font-bold text-right my-3 whitespace-nowrap">
+            {car.model}
+          </h1>
+          <p className="text-gray-600 max-w-[400px] text-right break-words">
+            {car.description}
+          </p>
+          <ul className="flex flex-col my-2">
+            <li className="flex justify-between min-w-[8rem] text-sm font-semibold px-2 py-1 even:bg-gray-300 odd:bg-gray-50 ">
+              <span>Color:</span>
+              <span>{car.color}</span>
+            </li>
+            <li className="flex justify-between min-w-[8rem] text-sm font-semibold px-2 py-1 even:bg-gray-300 odd:bg-gray-50 ">
+              <span>Tax:</span>
+              <span>${(car.price * 0.1).toFixed(2)}</span>
+            </li>
+            <li className="flex justify-between min-w-[8rem] text-sm font-semibold px-2 py-1 even:bg-gray-300 odd:bg-gray-50 ">
+              <span>Car Rent: </span>
+              <span>${car.price}</span>
+            </li>
+            <li className="flex justify-between min-w-[8rem] text-sm font-semibold px-2 py-1 even:bg-gray-300 odd:bg-gray-50 ">
+              <span>You Will Pay:</span>
+              <span>${(car.price + car.price * 0.1).toFixed(2)}</span>
+            </li>
+          </ul>
+          <Link
+            to="/reserve"
+            className="bg-lime-500 ml-auto max-w-fit mt-20 px-4 py-2 text-white flex items-center rounded-full hover:bg-lime-400 active:bg-lime-600"
+          >
+            Reserve <FaCheckCircle className="ml-4" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Details;

--- a/app/javascript/components/cars/Home.jsx
+++ b/app/javascript/components/cars/Home.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { FaFacebook, FaTwitter, FaInstagram } from 'react-icons/fa';
+import { BiRightArrow, BiLeftArrow } from 'react-icons/bi';
+import { useDispatch, useSelector } from 'react-redux';
+import { select } from '../../context/features/carSlice';
+import { Link } from 'react-router-dom';
+
+function Home(props) {
+  const { cars } = useSelector((state) => state.car);
+  const dispatch = useDispatch();
+
+  return (
+    <div className="relative w-full h-screen flex flex-col justify-start items-center overflow-auto max-h-screen max-w-full">
+      <button className="absolute left-0 top-1/2 bg-slate-300 text-white pl-8 py-4 pr-4 rounded-r-full">
+        <BiLeftArrow />
+      </button>
+      <button className="absolute right-0 top-1/2 bg-lime-500 text-white pr-8 py-4 pl-4 rounded-l-full">
+        <BiRightArrow />
+      </button>
+      <div className="flex flex-col justify-center items-center mt-12">
+        <h1 className="text-3xl font-bold text-slate-800">Availble Cars</h1>
+        <p className="text-slate-400 text-sm font-bold">
+          Please select your desired model
+        </p>
+        <p className="text-slate-400 my-4">••••••••••••••••</p>
+      </div>
+      <div className="flex justify-center items-center flex-wrap gap-x-4">
+        {cars.map((car) => (
+          <Link
+            key={car.id}
+            className="flex flex-col justify-center items-center cursor-pointer hover:bg-slate-50"
+            // onClick={() => handleCarSelect(car)}
+            to={`/cars/${car.id}`}
+          >
+            <div
+              className={`flex justify-center items-center overflow-visible rounded-full max-w-fit`}
+            >
+              <img
+                src={car.image_url}
+                width={500}
+                height={500}
+                alt={`${car.model}-image`}
+              />
+            </div>
+            <h2 className="text-xl font-bold">{car.model}</h2>
+            <p className="text-slate-400 my-2">••••••••••••••••</p>
+            <p className="text-slate-400 max-w-[400px] text-center break-words">
+              {car.description}
+            </p>
+            <ul className="flex justify-center items-center w-full mt-auto mb-4 pr-4">
+              <a
+                href="https://www.facebook.com"
+                className="m-2 text-slate-400 hover:scale-125 hover:border-blue-500 hover:text-blue-500 transition-transform rounded-full border-2 p-2"
+              >
+                <FaFacebook />
+              </a>
+              <a
+                href="https://www.twitter.com"
+                className="m-2 text-slate-400 hover:scale-125 hover:border-sky-400 hover:text-sky-400 transition-transform rounded-full border-2 p-2"
+              >
+                <FaTwitter />
+              </a>
+              <a
+                href="https://www.google.com"
+                className="m-2 text-slate-400 hover:scale-125 hover:border-red-400 hover:text-red-400 transition-transform rounded-full border-2 p-2"
+              >
+                <FaInstagram />
+              </a>
+            </ul>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Home;

--- a/app/javascript/components/cars/index.js
+++ b/app/javascript/components/cars/index.js
@@ -1,0 +1,2 @@
+export { default as Home } from './Home';
+export { default as Details } from './Details';

--- a/app/javascript/components/shared/index.js
+++ b/app/javascript/components/shared/index.js
@@ -1,0 +1,2 @@
+export { default as Toast } from './Toast';
+export { default as ToastContainer } from './ToastContainer';

--- a/app/javascript/context/features/carSlice.js
+++ b/app/javascript/context/features/carSlice.js
@@ -1,0 +1,107 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { axios } from '../../utils/api';
+
+const initialState = {
+  cars: [
+    {
+      id: 1,
+      model: 'Nissan ARIYA',
+      description:
+        'Nissan ARIYA is a daring glimpse of an automotive future others can only dream about.',
+      color: '#cdccdd',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/ariya/2023/overview/mini-exterior-360/XGJ/08-two-tone-sunrise-copper-pearl-black-diamond-metallic-nissan-ariya-front-left-view.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+    {
+      id: 2,
+      model: 'Nissan Rogue Sport',
+      description: 'Street-savvy, road-trip ready, always fun to drive',
+      color: '#be5e26',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/rogue_sport/2022/overview/mini-exterior-360/nbl/08.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+    {
+      id: 3,
+      model: 'Nissan ARIYA',
+      description:
+        'Nissan ARIYA is a daring glimpse of an automotive future others can only dream about.',
+      color: '#cdccdd',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/ariya/2023/overview/mini-exterior-360/XGJ/08-two-tone-sunrise-copper-pearl-black-diamond-metallic-nissan-ariya-front-left-view.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+    {
+      id: 4,
+      model: 'Nissan Rogue Sport',
+      description: 'Street-savvy, road-trip ready, always fun to drive',
+      color: '#be5e26',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/rogue_sport/2022/overview/mini-exterior-360/nbl/08.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+    {
+      id: 5,
+      model: 'Nissan ARIYA',
+      description:
+        'Nissan ARIYA is a daring glimpse of an automotive future others can only dream about.',
+      color: '#cdccdd',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/ariya/2023/overview/mini-exterior-360/XGJ/08-two-tone-sunrise-copper-pearl-black-diamond-metallic-nissan-ariya-front-left-view.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+    {
+      id: 6,
+      model: 'Nissan Rogue Sport',
+      description: 'Street-savvy, road-trip ready, always fun to drive',
+      color: '#be5e26',
+      image_url:
+        'https://www.nissanusa.com/content/dam/Nissan/us/vehicles/rogue_sport/2022/overview/mini-exterior-360/nbl/08.png.ximg.c1h.360.png',
+      price: 449.99,
+    },
+  ],
+  selected: null,
+  loading: false,
+  error: null,
+};
+
+const fetchCars = createAsyncThunk(
+  'cars/fetch',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await axios.get('/api/cars');
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response.data.error);
+    }
+  }
+);
+
+const carSlice = createSlice({
+  name: 'car',
+  initialState,
+  reducers: {
+    select: (state, action) => {
+      state.selected = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchCars.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(fetchCars.fulfilled, (state, action) => {
+      state.cars = action.payload;
+      state.loading = false;
+      state.error = null;
+    });
+    builder.addCase(fetchCars.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    });
+  },
+});
+
+export default carSlice.reducer;
+export const { select } = carSlice.actions;
+export { fetchCars };

--- a/app/javascript/context/store.js
+++ b/app/javascript/context/store.js
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './features/userSlice';
 import toastReducer from './features/toastSlice';
+import carReducer from './features/carSlice';
 
 export const store = configureStore({
-  reducer: { user: userReducer, toast: toastReducer },
+  reducer: { user: userReducer, toast: toastReducer, car: carReducer },
 });

--- a/app/javascript/utils/api.js
+++ b/app/javascript/utils/api.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { getUser } from './auth';
+
+const authFetch = axios.create({
+  headers: {
+    Authorization: `Bearer ${getUser(false)}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+});
+
+export { authFetch as axios };

--- a/app/javascript/utils/auth.js
+++ b/app/javascript/utils/auth.js
@@ -1,12 +1,11 @@
 import jwtDecode from 'jwt-decode';
 import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 const TOKEN_KEY = 'token';
 
-function getUser() {
+function getUser(decode = true) {
   const token = localStorage.getItem(TOKEN_KEY);
-  if (token) return jwtDecode(token);
+  if (token) return decode ? jwtDecode(token) : token;
   return null;
 }
 


### PR DESCRIPTION
# In this branch I have implemented the following requirements
- On the main page, the user can see a list of Cars.
- When the user selects a specific item, they can see the [details page](https://www.behance.net/gallery/26425031/Vespa-Responsive-Redesign/modules/173005579) with its full description (skip the "Rotate image" button).
- In the details page, the user can click the "Reserve" button (in the design you can see the "Configure" button - please replace it with the "Reserve" button).

Here are the previews

![image](https://github.com/BahirHakimy/rent-a-car/assets/73453971/d2e986d3-e76e-480b-84d8-827372a9c9b3)

![image](https://github.com/BahirHakimy/rent-a-car/assets/73453971/25458bd0-67a0-4699-aea4-eb0e7694d8dd)

closes #3 
closes #4 